### PR TITLE
Fix retweet handling

### DIFF
--- a/bot/utils/processor.py
+++ b/bot/utils/processor.py
@@ -182,7 +182,14 @@ class Processor:
         )
 
     def get_text(self):
-        if "extended_tweet" in self.status_tweet:
+        if "retweeted_status" in self.status_tweet:
+            if "extended_tweet" in self.status_tweet["retweeted_status"]:
+                self.text = self.status_tweet["retweeted_status"]["extended_tweet"]["full_text"]
+            elif "full_text" in self.status_tweet["retweeted_status"]:
+                self.text = self.status_tweet["retweeted_status"]["full_text"]
+            else:
+                self.text = self.status_tweet["retweeted_status"]["text"]
+        elif "extended_tweet" in self.status_tweet:
             self.text = self.status_tweet["extended_tweet"]["full_text"]
         elif "full_text" in self.status_tweet:
             self.text = self.status_tweet["full_text"]
@@ -231,38 +238,73 @@ class Processor:
         return blackword_set_present(self.discord_config.get("blackword_sets", [[""]]), self.text)
 
     def attach_media(self):
-        if (
-            "extended_tweet" in self.status_tweet
-            and "media" in self.status_tweet["extended_tweet"]["entities"]
-        ):
-            for media in self.status_tweet["extended_tweet"]["entities"]["media"]:
-                if media["type"] == "photo":
-                    self.embed.set_image(url=media["media_url_https"])
-                elif media["type"] == "video":
-                    pass
-                elif media["type"] == "animated_gif":
-                    pass
+        if "retweeted_status" in self.status_tweet:
+            if (
+                "extended_tweet" in self.status_tweet["retweeted_status"]
+                and "media" in self.status_tweet["retweeted_status"]["extended_tweet"]["entities"]
+            ):
+                for media in self.status_tweet["retweeted_status"]["extended_tweet"]["entities"]["media"]:
+                    if media["type"] == "photo":
+                        self.embed.set_image(url=media["media_url_https"])
+                    elif media["type"] == "video":
+                        pass
+                    elif media["type"] == "animated_gif":
+                        pass
 
-        if "media" in self.status_tweet["entities"]:
-            for media in self.status_tweet["entities"]["media"]:
-                if media["type"] == "photo":
-                    self.embed.set_image(url=media["media_url_https"])
-                elif media["type"] == "video":
-                    pass
-                elif media["type"] == "animated_gif":
-                    pass
+            if "media" in self.status_tweet["retweeted_status"]["entities"]:
+                for media in self.status_tweet["retweeted_status"]["entities"]["media"]:
+                    if media["type"] == "photo":
+                        self.embed.set_image(url=media["media_url_https"])
+                    elif media["type"] == "video":
+                        pass
+                    elif media["type"] == "animated_gif":
+                        pass
 
-        if (
-            "extended_entities" in self.status_tweet
-            and "media" in self.status_tweet["extended_entities"]
-        ):
-            for media in self.status_tweet["extended_entities"]["media"]:
-                if media["type"] == "photo":
-                    self.embed.set_image(url=media["media_url_https"])
-                elif media["type"] == "video":
-                    pass
-                elif media["type"] == "animated_gif":
-                    pass
+            if (
+                "extended_entities" in self.status_tweet["retweeted_status"]
+                and "media" in self.status_tweet["retweeted_status"]["extended_entities"]
+            ):
+                for media in self.status_tweet["retweeted_status"]["extended_entities"]["media"]:
+                    if media["type"] == "photo":
+                        self.embed.set_image(url=media["media_url_https"])
+                    elif media["type"] == "video":
+                        pass
+                    elif media["type"] == "animated_gif":
+                        pass
+        else:
+            if (
+                "extended_tweet" in self.status_tweet
+                and "media" in self.status_tweet["extended_tweet"]["entities"]
+            ):
+                for media in self.status_tweet["extended_tweet"]["entities"]["media"]:
+                    if media["type"] == "photo":
+                        self.embed.set_image(url=media["media_url_https"])
+                    elif media["type"] == "video":
+                        pass
+                    elif media["type"] == "animated_gif":
+                        pass
+
+            if "media" in self.status_tweet["entities"]:
+                for media in self.status_tweet["entities"]["media"]:
+                    if media["type"] == "photo":
+                        self.embed.set_image(url=media["media_url_https"])
+                    elif media["type"] == "video":
+                        pass
+                    elif media["type"] == "animated_gif":
+                        pass
+
+            if (
+                "extended_entities" in self.status_tweet
+                and "media" in self.status_tweet["extended_entities"]
+            ):
+                for media in self.status_tweet["extended_entities"]["media"]:
+                    if media["type"] == "photo":
+                        self.embed.set_image(url=media["media_url_https"])
+                    elif media["type"] == "video":
+                        pass
+                    elif media["type"] == "animated_gif":
+                        pass
+            
 
     def create_embed(self):
         self.embed = Embed(


### PR DESCRIPTION
Previously, retweets would not be posted using tweepy's extended mode.
New if statements allow retweets to go through their own set of checks to allow identical handling to regular tweets.
This also applies to the media retweeted as well.