### PR TITLE
Use unbuffered python output in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,5 @@ RUN \
   /tmp/* \
   /var/cache/apk/*
 
-CMD ["python", "bot/main.py"]
+CMD ["python", "-u", "bot/main.py"]
 


### PR DESCRIPTION
Calling python with the `-u` parameter uses unbuffered stdout and stderr allowing output to be read in `docker logs` etc.