### PR TITLE
Added Twitter list support by list id

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This is a powerful twitter bot for discord. It allows you to follow up to 5000 T
 
 Installation can be quick and easy through Heroku (one-click deployment, [see video](https://www.youtube.com/watch?v=NwPcXBvStSI)). A multi-architecture Docker image is also provided for the Docker people.
 
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 Installations have been written for:
 
 * [Ubuntu](http://nntin.github.io/discord-twitter-bot/docs/inst-ubuntu/)

--- a/bot/utils/twitter_id_converter.py
+++ b/bot/utils/twitter_id_converter.py
@@ -66,11 +66,11 @@ class Converter:
 
     def twitter_list_to_id(self, twitter_list_url: str) -> list:
         twitter_ids = []
-        pattern = "(https?:\/\/(?:www\.)?)?twitter\.com\/(?P<twittername>[a-zA-Z0-9]+)\/lists\/(?P<listname>[a-zA-Z0-9-]+)"
+        pattern = "(https?:\/\/(?:www\.)?)?twitter\.com\/(i\/lists\/(?P<list_id>[a-zA-Z0-9-]+)|(?P<owner_screen_name>[a-zA-Z0-9]+)\/lists\/(?P<slug>[a-zA-Z0-9-]+))"
         for m in re.finditer(pattern, twitter_list_url, re.I):
             try:
                 for member in Cursor(
-                    self.client.list_members, m.group("twittername"), m.group("listname")
+                    self.client.list_members, list_id=m.group("list_id"), owner_screen_name=m.group("owner_screen_name"), slug=m.group("slug")
                 ).items():
                     twitter_id = member._json["id_str"]
                     if twitter_id not in twitter_ids:


### PR DESCRIPTION
Previously it accepted https://twitter.com/rokxx/lists/dota-2 but not https://twitter.com/i/lists/119945637 even though they are basically the same URL.

Adjusted the code to accept both variants.

Added Heroku Deploy Button back into ReadMe.

Stylecheck is failing. Will fix sometime when merging into master.